### PR TITLE
Disabling the version check mode

### DIFF
--- a/schemas/event/1.0/config.json
+++ b/schemas/event/1.0/config.json
@@ -56,7 +56,7 @@
     "targetTopicIds"
   ],
   "version": "enable",
-  "versionCheckMode": "ON",
+  "versionCheckMode": "OFF",
   "cacheEnabled": false,
   "schema_restrict_api": false
 }


### PR DESCRIPTION
1. It was changed during the dev activity of event edit and publish for testing, its reverted through this commit.
2. Its being reverted since its breaking the publish flow after editing -tested in local reverting to original value its working fine.