### PR TITLE
KB-12601 | BE|DEV| Schema extension for learning pathway - for assessments

### DIFF
--- a/schemas/questionset/1.0/schema.json
+++ b/schemas/questionset/1.0/schema.json
@@ -868,7 +868,9 @@
       "enum": [
         "Final Program Assessment",
         "Final Program Assessment UnLocked",
-        "Pre Enrolment Assessment"
+        "Pre Enrolment Assessment",
+        "Preliminiary Assessment",
+        "Final Milestone Assessment"
       ]
     },
     "sectorDetails_v1": {
@@ -879,6 +881,9 @@
     },
     "isMandatory": {
         "type": "boolean"
+    },  
+    "coolOffPeriod": {
+        "type": "number"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION

1. Schema extension for the cooloffperiod to retake the assessment - its a number field which stores the number of days to restrict the assessment consumption once threshold of max attempt is reached.
2. Added new context category for assessments for learning pathway.